### PR TITLE
Add vertical spacing around list items in drink notes

### DIFF
--- a/src/components/notes.js
+++ b/src/components/notes.js
@@ -37,6 +37,9 @@ const Notes = ({ children }) => (
       ul {
         list-style-type: square;
       }
+      ul li {
+        margin: 1.25rem 0;
+      }
     `}
     dangerouslySetInnerHTML={{
       __html: children,


### PR DESCRIPTION
This should impose vertical spacing between list items, regardless of whether or not there is an empty line between list items in the data from Contentful. Adding an empty line in Contentful actually wraps the list item text in a paragraph tag, which comes with its own margin. This solution works due to [margin collapsing](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing).