### PR TITLE
fix(dialog): avoid content jump when showing feedback form

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -53,7 +53,6 @@ function Layout({ children, onSearchTermChange, withSearch }) {
                   }
                   html {
                     background-color: #242424;
-                    overflow-y: scroll;
                   }
                   body {
                     font-family: 'Source Sans Pro', -apple-system,
@@ -61,6 +60,15 @@ function Layout({ children, onSearchTermChange, withSearch }) {
                       'helvetica neue', helvetica, ubuntu, roboto, noto,
                       'segoe ui', arial, sans-serif;
                     font-weight: 300;
+                  }
+                  /*
+                   * HACK: abuse specificity to force styles overridden by
+                   * @reach/dialog -> react-remove-scroll -> react-remove-scroll-bar
+                   * to avoid a content jump when showing the feedback form.
+                   */
+                  html > body {
+                    overflow-y: scroll !important;
+                    margin: 0 !important;
                   }
                   #gatsby-noscript {
                     display: none;


### PR DESCRIPTION
@reach/dialog v0.2.0 (bb429a15fed88ff446bfa83174ebafb6f50953b9) introduced the use of react-remove-scroll and react-remove-scroll-bar, which makes an opinionated choice to hide the scroll bar and add margin to the body to offset the missing scroll bar width. This causes the page content to jump upon opening the feedback form. Abusing CSS specificity to force our own overflow-y and margin values remedies this until the use of react-remove-scroll is customizable in @reach/dialog (if that ever even happens).