### PR TITLE
revert: chore(deps): update typeface-source-sans-pro to v1 (#82)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "react-helmet": "6.0.0",
     "react-icons": "3.10.0",
     "react-instantsearch-dom": "6.4.0",
-    "typeface-source-sans-pro": "1.1.5"
+    "typeface-source-sans-pro": "0.0.75"
   },
   "devDependencies": {
     "@commitlint/cli": "8.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17849,10 +17849,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typeface-source-sans-pro@1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/typeface-source-sans-pro/-/typeface-source-sans-pro-1.1.5.tgz#5b6a009f79888e9d4053d617772805fe79a941cc"
-  integrity sha512-a+KZN2X7gzZ91RUKB/9zAiEtRuD+aX7dwNTo121vpZz2MVODWSJfw81XZQmIwZ4jD/5658EMvPJHttS6qT0gZA==
+typeface-source-sans-pro@0.0.75:
+  version "0.0.75"
+  resolved "https://registry.yarnpkg.com/typeface-source-sans-pro/-/typeface-source-sans-pro-0.0.75.tgz#33e60ea079738c2dbdb2d0aa28f899f565e1646e"
+  integrity sha512-8aI6ywe+5py1MoMQjdnuQKepOATSLpFoyatVMweF6JNUD8cu+sWaVEfZBN08CRxPrSC4KYTArf6prrQzcqpyQA==
 
 uglify-js@^3.1.4:
   version "3.7.3"


### PR DESCRIPTION
v0.0.75 references the latin font filenames and looks good.
v1.1.5 references the non-latin font filenames and looks bad.

This reverts commit c34dfdef5502449e6fe501914d0f0d435bc1d418.